### PR TITLE
Change button text from Install to Download for Clarity

### DIFF
--- a/js/download-app.mjs
+++ b/js/download-app.mjs
@@ -9,20 +9,20 @@ export class DownloadApp extends HTMLElement {
     const storedData = JSON.parse(localStorage.getItem("store"));
     const data = storedData.find((item) => item.name === getQueryParam("name"));
     this.render(data);
-    const installButton = this.shadowRoot.querySelector("md-filled-button");
+    const downloadButton = this.shadowRoot.querySelector("md-filled-button");
     const progressBar = this.shadowRoot.querySelector("md-circular-progress");
     const progressText = this.shadowRoot.querySelector(".progress-text");
     const mainElement = this.shadowRoot.querySelector(".main");
 
     if (data.type === "PWA" && data.pwa_link) {
-      installButton.setAttribute("href", data.pwa_link);
-      installButton.setAttribute("target", "_blank");
-      installButton.textContent = "Open";
+      downloadButton.setAttribute("href", data.pwa_link);
+      downloadButton.setAttribute("target", "_blank");
+      downloadButton.textContent = "Open";
     } else {
-      installButton.addEventListener("click", async () => {
+      downloadButton.addEventListener("click", async () => {
         if ("setAppBadge" in navigator) navigator.setAppBadge();
-        installButton.setAttribute("disabled", "true");
-        installButton.textContent = "Installing...";
+        downloadButton.setAttribute("disabled", "true");
+        downloadButton.textContent = "Downloading...";
         const url = `https://raw.githubusercontent.com/LiquidGalaxyLAB/Data/refs/heads/main${data.base_url}${data.file}`;
         const response = await fetch(url);
         const contentLength = response.headers.get("content-length");
@@ -31,8 +31,8 @@ export class DownloadApp extends HTMLElement {
           alert(
             "Unable to fetch content length. Progress tracking may not work."
           );
-          installButton.removeAttribute("disabled");
-          installButton.textContent = "Install";
+          downloadButton.removeAttribute("disabled");
+          downloadButton.textContent = "Download";
           if ("setAppBadge" in navigator) navigator.setAppBadge(0);
           return;
         }
@@ -70,8 +70,8 @@ export class DownloadApp extends HTMLElement {
         a.click();
 
         URL.revokeObjectURL(downloadUrl);
-        installButton.removeAttribute("disabled");
-        installButton.textContent = "Install";
+        downloadButton.removeAttribute("disabled");
+        downloadButton.textContent = "Download";
         if ("setAppBadge" in navigator) navigator.setAppBadge(0);
       });
     }
@@ -199,7 +199,7 @@ export class DownloadApp extends HTMLElement {
       </div>
       <div class="button">
         <md-filled-button>${
-          data.type === "PWA" && data.pwa_link ? "Open" : "Install"
+          data.type === "PWA" && data.pwa_link ? "Open" : "Download"
         }</md-filled-button>
       </div>
     `;


### PR DESCRIPTION
On clicking the button an apk is downloaded so Download would be a better naming for this button.
(as proposed in discord meeting)

After the change :
<img width="807" height="271" alt="image" src="https://github.com/user-attachments/assets/4fd2fbfc-46ab-4912-99f4-3ac7586cd768" />

<img width="807" height="271" alt="image" src="https://github.com/user-attachments/assets/fec13806-1f68-4083-9299-4457bda4bc79" />

---
Before the change:

<img width="807" height="271" alt="image" src="https://github.com/user-attachments/assets/76f19c94-34cb-43b5-ba04-3e43ba9f2f7d" />

<img width="807" height="271" alt="image" src="https://github.com/user-attachments/assets/8dcdb145-a1a6-433e-91f7-333b9032e33f" />

Tested locally and since no functional change is there works fine !


